### PR TITLE
Upstream deps

### DIFF
--- a/server/setup/download_dependencies.sh
+++ b/server/setup/download_dependencies.sh
@@ -103,9 +103,7 @@ fi
 if ! command -v bower >/dev/null; then
     $SUDO npm install -g bower
 fi
-bower init
-bower install --save Polymer/polymer
-bower install --save Polymer/core-elements
-bower install --save Polymer/paper-elements
+bower install Polymer/polymer
+bower install Polymer/core-elements
+bower install Polymer/paper-elements
 mv bower_components ../bower_components
-mv bower.json ../bower.json


### PR DESCRIPTION
So this PR might be a bit contentions, because:
- It sounds like internally this script actually lives upstream and is moved in
- The bower stuff might be entirely unnecessary

It's not super clear to me how bower works, but it still seems to do the right thing without the `init` step, and without it we can do this in a hands off fashion in CI.
