### PR TITLE
Actualy use the email from the request

### DIFF
--- a/server/report.py
+++ b/server/report.py
@@ -139,7 +139,7 @@ class ReportPageHandler(webapp2.RequestHandler):
     message.subject = PHISHING_ALERT_SUBJECT % self.request.get('url')
     message.body = (PHISHING_ALERT_BODY
                     % (self.request.get('referer'),
-                       self.request.get('username'),
+                       self.request.get('email'),
                        self.request.get('version')))
     message.send()
 


### PR DESCRIPTION
This may be a red herring, but requests we're seeing from the latest extesnion (0.40.10) have no username field, but do contain email.

(This has been happening since we started working with it, but I forgot to PR)
