### PR TITLE
Append corp_html to provided Google login page

### DIFF
--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -421,6 +421,13 @@ passwordcatcher.handleManagedPolicyChanges_ =
     function(changedPolicies, storageNamespace) {
   if (storageNamespace == passwordcatcher.MANAGED_STORAGE_NAMESPACE_) {
     console.log('Handling changed policies.');
+
+    var subtractArray = function(currentPolicyArray, oldPolicyArray) {
+      return currentPolicyArray.filter(
+        function(val) { return oldPolicyArray.indexOf(val) < 0; }
+      );
+    };
+
     var changedPolicy;
     for (changedPolicy in changedPolicies) {
       if (!passwordcatcher.isEnterpriseUse_) {
@@ -428,16 +435,26 @@ passwordcatcher.handleManagedPolicyChanges_ =
         console.log('Enterprise use via updated managed policy.');
       }
       var newPolicyValue = changedPolicies[changedPolicy]['newValue'];
+      var oldPolicyValue = changedPolicies[changedPolicy]['oldValue'];
       switch (changedPolicy) {
         case 'corp_email_domain':
           passwordcatcher.corp_email_domain_ = newPolicyValue;
           break;
         case 'corp_html':
+          // Remove the old values before appending new ones
+          passwordcatcher.corp_html_ = subtractArray(
+            passwordcatcher.corp_html_,
+            oldPolicyValue);
+
           passwordcatcher.corp_html_.push.apply(
             passwordcatcher.corp_html_,
             newPolicyValue);
           break;
         case 'corp_html_tight':
+          passwordcatcher.corp_html_tight_ = subtractArray(
+            passwordcatcher.corp_html_tight_,
+            oldPolicyValue);
+
           passwordcatcher.corp_html_tight_.push.apply(
             passwordcatcher.corp_html_tight_,
             newPolicyValue);


### PR DESCRIPTION
Append `corp_html` to the Google login page html rather than overwriting (per @adhintz suggestion).

This also handles removal of the previous policy values whenever a policy changes -- in case an admin is trying to fix a policy that breaks _all the things_ (e.g. a super generic `corp_html` phrase found on every site).

(FWIW, I haven't been able to easily test this, since a private Chrome webstore version to try the managedPolicy is stuck in webstore limbo.)
