### PR TITLE
Fix closure rewriting this API

### DIFF
--- a/chrome/externs.js
+++ b/chrome/externs.js
@@ -35,6 +35,7 @@ chrome.i18n.getMessage;
 
 chrome.identity;
 chrome.identity.getAuthToken;
+chrome.identity.getProfileUserInfo;
 
 chrome.notifications;
 chrome.notifications.create;


### PR DESCRIPTION
Seeing this in the latest deployed version:

```
Error in response to storage.get: TypeError: chrome.identity.i is not a function
    at P (chrome-extension://noondiphcddnnabmjcihcjfbhfklnnep/background_compiled.js:22:408)
    at Object.callback (chrome-extension://noondiphcddnnabmjcihcjfbhfklnnep/background_compiled.js:35:249)
    at chrome-extension://noondiphcddnnabmjcihcjfbhfklnnep/background_compiled.js:35:24
```

(I actually don't see this locally after `./do.sh clean ; ./do.sh build_extension` ... probably a local closure config issue.)

Signed-off-by: Nick Semenkovich semenko@alum.mit.edu
