### PR TITLE
server fixes

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -31,7 +31,6 @@ DOMAIN_AUTH_SECRET = ''
 # App Engine app's web interface, then please configure this section.
 
 # Where to send alert emails, such as security@example.com
-# This recipient needs to be an admin of the App Engine application.
 ALERTS_EMAIL = ''
 
 # The email that sends alerts to admins and users.
@@ -115,3 +114,5 @@ DOMAIN = os.getenv('AUTH_DOMAIN')
 OAUTH_CLIENT_ID = ''
 OAUTH_CLIENT_SECRET = ''
 OAUTH_REDIRECT_URI = ''
+
+CORP_EMAIL_DOMAIN = DOMAIN  # For working around Chrome vs server setting names.

--- a/server/password_change.py
+++ b/server/password_change.py
@@ -20,6 +20,7 @@ __author__ = 'adhintz@google.com (Drew Hintz)'
 from datetime import datetime
 from datetime import timedelta
 import logging
+import traceback
 
 import datastore
 import google_directory_service
@@ -82,6 +83,7 @@ def ChangePasswordAtNextLogin(email):
     google_directory_service.UpdateUserInfo(email, user_info)
     return {'result': 'OK'}
   except Exception as e:  # pylint: disable=broad-except
+    logging.warning(traceback.format_exc())
     return {'result': 'OTHER_ERROR', 'error_message': e}
 
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -21,6 +21,7 @@ import pickle
 
 from apiclient.errors import HttpError
 import config
+import datastore
 import google_directory_service
 from oauth2client import appengine
 from oauth2client import client
@@ -130,9 +131,13 @@ def LoadCredentialsFromPem():
 
 
 def _StoreCredentials(credentials):
+  if datastore.HOSTED:
+    domain = users.get_current_user().email().split('@')[1]
+  else:  # In non-hosted, the user will not be logged in on /report/ requests.
+    domain = config.DOMAIN.split(',')[0]
   credential_storage = appengine.StorageByKeyName(
       appengine.CredentialsModel,
-      users.get_current_user().email().split('@')[1],
+      domain,
       'credentials')
   credential_storage.put(credentials)
 


### PR DESCRIPTION
- corp_email_domain set to domain to work with new setting name
- _StoreCredentials works if the credentials need to be refreshed on a /report/ request
- extra debugging on password change exception
- in non-Hosted mode, allow App Engine admin access for a simple configuration case, such as where no service account is configured.
