### PR TITLE
Fixed timing leak of password length

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -582,8 +582,7 @@ passwordalert.background.handleKeypress_ = function(tabId, request) {
   }
 
   for (var i = 1; i < passwordalert.background.passwordLengths_.length; i++) {
-    if (passwordalert.background.passwordLengths_[i] &&
-        passwordalert.background.tabState_[tabId]['typedChars'].length >= i) {
+    if (passwordalert.background.passwordLengths_[i]) {
       request.password = passwordalert.background
           .tabState_[tabId]['typedChars'].substr(-1 * i);
       passwordalert.background.checkPassword_(tabId, request, false);


### PR DESCRIPTION
I couldn't get the attack code working so this seems like a minor issue.

The attack code:
```
var length = 0, startTime;

function down(e)
{
	startTime = performance.now();
	while (startTime == performance.now());
	startTime = performance.now();
}

function press(e)
{
	length++;
	var count = 0, timeDiff;
	while (startTime == performance.now())
	{
		count++;
	}
	timeDiff = performance.now() - startTime;

	var node = document.createElement("div");
	node.innerHTML = length + " - " + count + " - " + timeDiff;
	document.getElementById("asdf").appendChild(node);
}

window.addEventListener('keydown', down, true);
window.addEventListener('keypress', press, true);
```
What should happen is down() is called before Password Alert's keypress event and press() is called after. With accurate timing you \*should\* be able to tell at what length SHA1 starts being called, but this was not the case in my tests.