### PR TITLE
Fixed stopImmediatePropagation() bypass

### DIFF
--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -445,7 +445,6 @@ passwordalert.completePageInitialization_ = function() {
         passwordalert.start_(msg);
       });
   chrome.runtime.sendMessage({action: 'statusRequest'});
-  window.addEventListener('keypress', passwordalert.handleKeypress_, true);
 };
 
 
@@ -961,3 +960,5 @@ chrome.storage.onChanged.addListener(
     passwordalert.handleManagedPolicyChanges_);
 
 passwordalert.initializePage_();
+
+window.addEventListener('keypress', passwordalert.handleKeypress_, true);

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -29,7 +29,8 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content_script_compiled.js"],
-      "all_frames": true
+      "all_frames": true,
+      "run_at": "document_start"
     }
   ],
 


### PR DESCRIPTION
```
<script type="text/javascript">
window.addEventListener("keypress",
  function (e)
  {
    e.stopImmediatePropagation();
  }, true);
</script>
```