### PR TITLE
add myaccount.google.com to the domain whitelist. It hosts a password change form.

### DIFF
--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -156,7 +156,8 @@ passwordalert.security_email_address_;
  */
 passwordalert.whitelist_top_domains_ = [
   'accounts.google.com',
-  'login.corp.google.com'
+  'login.corp.google.com',
+  'myaccount.google.com'
 ];
 
 


### PR DESCRIPTION
It has HSTS, but not yet HSTS preload in Chrome. I'm looking into adding it to preload list.