### PR TITLE
Added display_user_alert config option

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -178,6 +178,11 @@ passwordalert.background.isEnterpriseUse_ = false;
  */
 passwordalert.corp_email_domain_;
 
+/**
+ * Display the consumer mode alert even in enterprise mode.
+ * @private {boolean}
+ */
+passwordalert.background.displayUserAlert_ = false;
 
 /**
  * Domain-specific shared auth secret for enterprise when oauth token fails.
@@ -246,6 +251,8 @@ passwordalert.background.setManagedPolicyValuesIntoConfigurableVariables_ =
       console.log('Managed policy found.  Enterprise use.');
       passwordalert.background.corp_email_domain_ =
           managedPolicy['corp_email_domain'].replace(/@/g, '').toLowerCase();
+      passwordalert.background.displayUserAlert_ =
+          managedPolicy['display_user_alert'];
       passwordalert.background.isEnterpriseUse_ = true;
       passwordalert.background.report_url_ = managedPolicy['report_url'];
       passwordalert.background.shouldInitializePassword_ =
@@ -789,7 +796,7 @@ passwordalert.background.checkPassword_ = function(tabId, request, otpAlert) {
  */
 passwordalert.background.injectPasswordWarningIfNeeded_ =
     function(url, email, tabId) {
-  if (passwordalert.background.isEnterpriseUse_) {
+  if (passwordalert.background.isEnterpriseUse_ && !passwordalert.displayUserAlert_) {
     return;
   }
 

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -297,6 +297,9 @@ passwordalert.background.handleManagedPolicyChanges_ =
           passwordalert.background.corp_email_domain_ =
               newPolicyValue.replace(/@/g, '').toLowerCase();
           break;
+        case 'display_user_alert':
+          passwordalert.background.displayUserAlert_ = newPolicyValue;
+          break;
         case 'report_url':
           passwordalert.background.report_url_ = newPolicyValue;
           break;

--- a/chrome/managed_policy_schema.json
+++ b/chrome/managed_policy_schema.json
@@ -2,6 +2,7 @@
   "type": "object",
   "properties": {
     "corp_email_domain": {"type": "string"},
+    "display_user_alert": {"type": "boolean"},
     "corp_html": {
       "type": "array",
       "items": {"type": "string"}

--- a/chrome/managed_policy_values.txt
+++ b/chrome/managed_policy_values.txt
@@ -4,7 +4,7 @@
   },
   "display_user_alert": {
     "Value": false
-  }.
+  },
   "corp_html": {
     "Value": ["CHANGE ME Your Example Company Name",
               "CHANGE ME Some text from your SSO Page"]

--- a/chrome/managed_policy_values.txt
+++ b/chrome/managed_policy_values.txt
@@ -2,6 +2,9 @@
   "corp_email_domain": {
     "Value": "@example.com"
   },
+  "display_user_alert": {
+    "Value": false
+  }.
   "corp_html": {
     "Value": ["CHANGE ME Your Example Company Name",
               "CHANGE ME Some text from your SSO Page"]


### PR DESCRIPTION
Some organizations may be interested in getting the best of consumer and enterprise mode. This change will allow administrators to modify a configuration option (display_user_alert) which will have the chrome extension display to consumer mode password alert, even in enterprise mode.