### PR TITLE
handle keyPress events for two uses: 1) in case keyDown does not work…

### DIFF
--- a/chrome/keydown.js
+++ b/chrome/keydown.js
@@ -103,6 +103,9 @@ passwordalert.keydown.MAP_ = {
 passwordalert.keydown.Typed = function(opt_chars) {
   this.caps_lock_ = false;  // Caps lock state.
   this.chars_ = opt_chars || '';
+  Object.defineProperty(this, 'length', { get: function() {
+    return this.chars_.length;
+  }});
 };
 
 
@@ -180,15 +183,6 @@ passwordalert.keydown.Typed.prototype.trim = function(max) {
   if (this.chars_.length > max) {
     this.chars_ = this.chars_.slice(-1 * max);
   }
-};
-
-
-/**
- * Length of characters that have been typed.
- * @return {number} Length of character string.
- */
-passwordalert.keydown.Typed.prototype.length = function() {
-  return this.chars_.length;
 };
 
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.7",
+  "version": "1.8",
   "default_locale": "en",
   "minimum_chrome_version": "33",
   "icons": { "128": "icon128.png" },


### PR DESCRIPTION
handle keyPress events for two uses: 1) in case keyDown does not work, such as certain special characters on international keyboards, 2) to help keyDown guess the capslock state.

Other changes:
 - fix OTP mode: checkPassword was relying on request.password.length even in otp mode
 - keydown objects now have a length property instead of length method. This makes it more similar to strings.
 - better jsdoc type
 - increment manifest version