### PR TITLE
Do not display a warning banner on OTP being typed.

### DIFF
--- a/chrome/background_test.js
+++ b/chrome/background_test.js
@@ -286,7 +286,7 @@ function testTypedCharsBufferTrimming() {
 
   var checkedPasswords = [];
   passwordalert.background.checkPassword_ = function(
-      tabId, request, state, otp) {
+      tabId, request, state) {
     checkedPasswords.push(request.password);
   };
 
@@ -312,12 +312,19 @@ function testOtpMode() {
   passwordalert.background.MINIMUM_PASSWORD_ = 2;
 
   alertCalled = false;
-  passwordalert.background.checkPassword_ =
-      function(tabId, request, state, otpAlert) {
+  passwordalert.background.sendReportPassword_ =
+      function(request, email, date, otpAlert) {
     if (otpAlert) {
       alertCalled = otpAlert;
     }
+  };
+
+  passwordalert.background.checkPassword_ = function(tabId, request, state) {
     if (request.password == 'pw') {
+      localStorage['pwhash'] = JSON.stringify(
+          {'email': 'adhintz@google.com',
+           'date': 1});
+      state['hash'] = 'pwhash';
       state['otpCount'] = 0;
       state['otpMode'] = true;
       state['otpTime'] = state['typedTime'];


### PR DESCRIPTION
Do not display a warning banner on OTP being typed. This fixes a bug where a user could type their password, dismiss the warning, then type 6 digits, and see another warning.

When in OTP mode, do not check password typing. This fixes a bug where a user could type their password in a legitimate login page, change tabs to a random website, then press a non-printable character such as Ctrl, and then a warning banner would be displayed for the random website.

Clear state['typed'] when leaving OTP mode.

Refactor OTP alerts out of checkPassword_().