### PR TITLE
Fix do.sh to copy warning files + copy the _locales directory properly on OSX

### DIFF
--- a/chrome/do.sh
+++ b/chrome/do.sh
@@ -88,7 +88,9 @@ pc_build_extension() {
   cp -f *.png "$BUILD_EXT_DIR"
   cp -f *.json "$BUILD_EXT_DIR"
   cp -f *.css "$BUILD_EXT_DIR"
-  cp -fR _locales/ "$BUILD_EXT_DIR"
+  cp -f password_warning.* "$BUILD_EXT_DIR"
+  cp -f phishing_warning.* "$BUILD_EXT_DIR"
+  cp -fR _locales "$BUILD_EXT_DIR"
   echo "Done."
 }
 


### PR DESCRIPTION
Two changes:
* Warning files don't actually get copied to `$BUILD_EXT_DIR` when running `./do.sh build_extension`.
* On OS X, `cp -fR _locales/  "$BUILD_EXT_DIR"` actually copies the contents of `_locales` instead of the directory itself.

I tested the fix under OS X 10.10.3 and Ubuntu 14.02.