### PR TITLE
Fix preloaded sites not getting messages.

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -534,6 +534,10 @@ passwordalert.background.handleRequest_ = function(
       break;
     case 'statusRequest':
       passwordalert.background.pushToTab_(sender.tab.id);
+      var state = {
+        passwordLengths: passwordalert.background.passwordLengths_
+      };
+      sendResponse(JSON.stringify(state));  // Needed for pre-loaded pages.
       break;
     case 'looksLikeGoogle':
       passwordalert.background.sendReportPage_(request);

--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -493,15 +493,10 @@ passwordalert.completePageInitializationIfReady_ = function() {
     chrome.runtime.sendMessage({action: 'savePossiblePassword'});
   }
 
-  chrome.runtime.onMessage.addListener(
-      /**
-       * @param {string} msg JSON object containing valid password lengths.
-       */
-      function(msg) {
-        passwordalert.stop_();
-        passwordalert.start_(msg);
-      });
-  chrome.runtime.sendMessage({action: 'statusRequest'});
+  chrome.runtime.sendMessage({action: 'statusRequest'}, function(response) {
+    passwordalert.stop_();
+    passwordalert.start_(response);
+  });
 };
 
 
@@ -850,6 +845,15 @@ window.addEventListener('keydown', passwordalert.handleKeydown_, true);
 window.addEventListener('paste', function(evt) {
   passwordalert.handlePaste_(evt);
 }, true);
+chrome.runtime.onMessage.addListener(
+    /**
+     * @param {string} msg JSON object containing valid password lengths.
+     */
+    function(msg) {
+      passwordalert.stop_();
+      passwordalert.start_(msg);
+    }
+);
 document.addEventListener('DOMContentLoaded', function() {
   passwordalert.domContentLoaded_ = true;
   passwordalert.completePageInitializationIfReady_();


### PR DESCRIPTION
Use the responseCallback feature of chrome.runtime.sendMessage. Similarly, onMessage has a sendResponse within the callback:
https://developer.chrome.com/extensions/runtime#event-onMessage
Using this keeps the message channel open and seems to fix our problems.