### PR TITLE
Refactoring do.sh for building extension from source

### DIFF
--- a/chrome/compiler.flags
+++ b/chrome/compiler.flags
@@ -2,5 +2,4 @@
 --externs=externs.js
 --only_closure_dependencies
 --manage_closure_dependencies
---js lib/closure-library/closure/goog/deps.js
 --js build/deps.js

--- a/chrome/do.sh
+++ b/chrome/do.sh
@@ -63,7 +63,7 @@ pc_build_extension() {
   echo "Building extension to $BUILD_EXT_DIR"
   rm -rf "$BUILD_EXT_DIR"
   mkdir -p "$BUILD_EXT_DIR"
-  SRC_DIRS=( lib/closure-library )
+  SRC_DIRS=( lib/closure-library/closure/goog )
 
   jscompile_pc="$JSCOMPILE_CMD"
   for var in "${SRC_DIRS[@]}"


### PR DESCRIPTION
1) Remove duplicate input called from compile.flags.
2) Fix SRC_DIRS to point to lib/closure-library/closure/goog from lib/closure-library

fixes #93 

