### PR TITLE
Update Password Alert to handle the new login page.

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -774,7 +774,8 @@ passwordalert.background.setPossiblePassword_ = function(tabId, request) {
   passwordalert.background.possiblePassword_[tabId] = {
     'email': request.email,
     'password': passwordalert.background.hashPassword_(request.password),
-    'length': request.password.length
+    'length': request.password.length,
+    'time': Math.floor(Date.now() / 1000)
   };
 };
 
@@ -805,6 +806,9 @@ passwordalert.background.savePossiblePassword_ = function(tabId) {
   var possiblePassword_ = passwordalert.background.possiblePassword_[tabId];
   if (!possiblePassword_) {
     return;
+  }
+  if ((Math.floor(Date.now() / 1000) - possiblePassword_['time']) > 60) {
+    return;  // If login took more than 60 seconds, ignore it.
   }
   var email = possiblePassword_['email'];
   var password = possiblePassword_['password'];
@@ -895,9 +899,8 @@ passwordalert.background.checkRateLimit_ = function() {
   var now = new Date();
   if (!passwordalert.background.rateLimitResetDate_ ||  // initialization case
       now >= passwordalert.background.rateLimitResetDate_) {
-    // setHours() handles wrapping correctly.
-    passwordalert.background.rateLimitResetDate_ =
-        now.setHours(now.getHours() + 1);
+    now.setHours(now.getHours() + 1);  // setHours() handles wrapping correctly.
+    passwordalert.background.rateLimitResetDate_ = now;
     passwordalert.background.rateLimitCount_ = 0;
   }
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.24",
+  "version": "1.25",
   "default_locale": "en",
   "minimum_chrome_version": "46",
   "icons": { "128": "icon128.png" },


### PR DESCRIPTION
Getting an event on document unload is a bit heavy, but I did not see a better way to get an event if the user presses enter after typing their password. The form submit event does not appear to be triggered. Alternatively we could listen on keypress for Enter and listen on passwordNext for click.

Update the logic for which pages under accounts.google.com indicate a correct password and which indicate an incorrect password.

If a possible password is too old, then delete it. This is probably not much an issue, but I want to avoid any issues around tabIds being reused.

Update the change password page to the new URL

----

save Date (not number) in passwordalert.background.rateLimitResetDate_

This JsDoc warning actually found a bug:
background.js:903: WARNING - assignment to property rateLimitResetDate_ of passwordalert.background
found   : number
required: (Date|null)
    passwordalert.background.rateLimitResetDate_ =
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Date.protogype.setHours() modifies the instance of Date and returns milliseconds, not the Date instance: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours

I don't think this bug actually had any effects, but this is more correct.