### PR TITLE
Updated for new login page and two factor

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.26",
+  "version": "1.27",
   "default_locale": "en",
   "minimum_chrome_version": "46",
   "icons": { "128": "icon128.png" },


### PR DESCRIPTION
Looks like Google updated their login page again and hashes for new users were not being saved. In our testing "gaia_loginform" seems to not exist on the login page. Additionally, we had problems with it saving the hash when two factor was enabled. To solve for these problems, we changed the way the Google login form is identified and store the username/password in temporary variables that are retrieved on form submit.

Tested with both consumer and enterprise modes.

Credit to Jacob Rickerd <jacobrickerd@gmail.com>, Zack Hardie <zackhardie@gmail.com>, and Duo Security.

Thanks for making an awesome tool!
