### PR TITLE
Add Google Chrome Remote Desktop corp origin to allowed domains

### DIFF
--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -189,7 +189,7 @@ passwordalert.security_email_address_;
  * @private {!Array.<string>}
  */
 passwordalert.whitelist_top_domains_ =
-    ['accounts.google.com', 'login.corp.google.com', 'myaccount.google.com'];
+    ['accounts.google.com', 'login.corp.google.com', 'myaccount.google.com', 'remotedesktop.corp.google.com'];
 
 
 /**


### PR DESCRIPTION
Without this password alert will show alerts on Google Chrome Remote Desktop origins during a remote desktop session. 
This is needed in cases where the extension policy isn't yet delivered to a device.