### PR TITLE
adding build directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 server/privatekey.pem
+chrome/build/
+chrome/lib/


### PR DESCRIPTION
This allows you to build locally without accidentally adding build artifacts to the repo on commit.  